### PR TITLE
Index document's text when available, and show snippet in search results

### DIFF
--- a/web/nuremberg/documents/models.py
+++ b/web/nuremberg/documents/models.py
@@ -1041,7 +1041,7 @@ class DocumentText(models.Model):
 
     @cached_property
     def slug(self):
-        return self.document.slug if self.document else slugify(self.title)
+        return self.document.slug() if self.document else slugify(self.title)
 
     @cached_property
     def source_name(self):

--- a/web/nuremberg/documents/search_indexes.py
+++ b/web/nuremberg/documents/search_indexes.py
@@ -18,6 +18,7 @@ class JsonField(indexes.CharField):
 
 class DocumentIndex(indexes.SearchIndex, indexes.Indexable):
     text = indexes.CharField(document=True, use_template=True)
+    highlight = indexes.CharField(model_attr='text')
     material_type = indexes.CharField(default='Document', faceted=True)
     grouping_key = indexes.FacetCharField(
         facet_for='grouping_key'

--- a/web/nuremberg/documents/templates/documents/show.html
+++ b/web/nuremberg/documents/templates/documents/show.html
@@ -74,11 +74,11 @@
       </p>
       {% if mode == 'image' and full_text %}
       <p class="trial-flags">
-        <a href="{% url 'documents:show' document_id=full_text.id slug=document.slug %}?mode=text{% if query %}&q={% encode_string query %}{% endif %}">Full-text View</a>
+        <a data-test="full-text-view" href="{% url 'documents:show' document_id=full_text.id slug=full_text.slug %}?mode=text{% if query %}&q={% encode_string query %}{% endif %}">Full-text View</a>
       </p>
       {% elif mode == 'text' and document.image_count %}
       <p class="trial-flags">
-        <a href="{% url 'documents:show' document_id=document.id slug=document.slug %}?mode=image{% if query %}&q={% encode_string query %}{% endif %}">Image View</a>
+        <a data-test="image-view" href="{% url 'documents:show' document_id=document.id slug=document.slug %}?mode=image{% if query %}&q={% encode_string query %}{% endif %}">Image View</a>
       </p>
       {% endif %}
       {% if mode != 'text' %}
@@ -189,7 +189,7 @@
     <div id="content"></div>
     {% if mode == 'text' %}
     <div class="main-column">
-      <div class="document-text">
+      <div class="document-text" data-test="document-text-viewport">
       {{ full_text.text|safe|linebreaks }}
       </div>
     </div>

--- a/web/nuremberg/documents/templates/documents/show.html
+++ b/web/nuremberg/documents/templates/documents/show.html
@@ -190,7 +190,7 @@
     {% if mode == 'text' %}
     <div class="main-column">
       <div class="document-text">
-      {{ full_text.text|linebreaks }}
+      {{ full_text.text|safe|linebreaks }}
       </div>
     </div>
     {% else %}

--- a/web/nuremberg/documents/tests/helpers.py
+++ b/web/nuremberg/documents/tests/helpers.py
@@ -1,15 +1,46 @@
 import pytest
-from django.db.models import Max
 from model_bakery import baker
 
-from nuremberg.documents.models import PersonalAuthorProperty
+from nuremberg.documents.models import Document, PersonalAuthorProperty
 
 
 @pytest.mark.django_db
 def make_author(**kwargs):
     # ensure baked authors have an ID higher than the current MAX author ID
     # in the properties table
-    max_id = PersonalAuthorProperty.objects.aggregate(
-        max_author_id=Max('personal_author_id')
-    )['max_author_id']
+    max_id = (
+        PersonalAuthorProperty.objects.all()
+        .order_by('personal_author_id')
+        .last()
+        .id
+    )
     return baker.make('DocumentPersonalAuthor', id=max_id + 10, **kwargs)
+
+
+def make_document(evidence_codes=None, **kwargs):
+    max_id = Document.objects.all().order_by('id').last().id
+    result = baker.make('Document', id=max_id, **kwargs)
+
+    db_evidence_codes = []
+    for code in evidence_codes or []:
+        prefix, number = code.split('-', 1)
+        db_evidence_codes.append(
+            baker.make(
+                'DocumentEvidenceCode',
+                prefix__code=prefix,
+                number=number,
+                document=result,
+            )
+        )
+
+    return result
+
+
+def make_random_text(length=100):
+    base = (
+        'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam '
+        'sagittis dolor et nisl mattis, at rutrum enim faucibus. Suspendisse '
+        'malesuada eros ligula, non hendrerit velit gravida et.'
+    )
+    result = base * ((len(base) // length) + 1)
+    return result[:length]

--- a/web/nuremberg/search/templates/search/document-row.html
+++ b/web/nuremberg/search/templates/search/document-row.html
@@ -14,13 +14,21 @@
         {% if result.literal_title %}
           <p>{{result.literal_title|truncatewords:35|truncatechars:300}}</p>
         {% endif %}
-
-        {% if result.material_type == 'Document' %}
-          <p>
-            <strong>HLSL Item No.:</strong>
-            {{result.pk}}
-          </p>
+        {% with result.text|trim_snippet as text %}
+        {% if text %}
+        <p class="snippets">
+            {% for snippet in result.highlighted.highlight %}
+              <span class="ellipsis">[ ... ]</span>
+              {{ snippet|trim_snippet }}
+            {% empty %}
+              <span class="ellipsis">[ ... ]</span>
+              {{ result.text|slice:":150"|trim_snippet }}
+            {% endfor %}
+          <span class="ellipsis">[ ... ]</span>
+        </p>
         {% endif %}
+        {% endwith %}
+        <p><strong>HLSL Item No.:</strong> {{result.pk}}</p>
       </a>
     {% elif result.material_type == 'Photograph' %}
       <a class="unstyled" href="{% url 'photographs:show' photograph_id=result.pk slug=result.slug %}{% if query %}?q={% encode_string query %}{% endif %}">

--- a/web/nuremberg/search/templates/search/indexes/documents/document_text.txt
+++ b/web/nuremberg/search/templates/search/indexes/documents/document_text.txt
@@ -1,3 +1,8 @@
+{{ object.text|safe }}
+
+{# this is a sentinel value used to hide these terms from highlighting snippets #}
+<end of text>
+
 {{ object.title }}
 
 {{ object.literal_title|default:"" }}

--- a/web/nuremberg/search/templatetags/search_url.py
+++ b/web/nuremberg/search/templatetags/search_url.py
@@ -138,4 +138,4 @@ def group_merge(results, key):
 
 @register.filter
 def trim_snippet(snippet):
-    return SafeString(snippet.split('<end of text>', 1)[0])
+    return SafeString((snippet.split('<end of text>', 1)[0]).strip())

--- a/web/nuremberg/settings.py
+++ b/web/nuremberg/settings.py
@@ -152,6 +152,7 @@ HAYSTACK_CONNECTIONS = {
     'default': {
         'ENGINE': 'nuremberg.search.lib.solr_grouping_backend.GroupedSolrEngine',
         'URL': 'http://solr:8983/solr/nuremberg_dev',
+        'TIMEOUT': 60 * 5,
     }
 }
 HAYSTACK_DEFAULT_OPERATOR = 'AND'


### PR DESCRIPTION
This branch adds a new field to the existing DocumentIndex search index model to allow for:

    full text search on those documents that have a corresponding plain text OCR'd version
    highlight of matching search terms in search results

The adding of the `<end of text>` custom tag in the `DocumentIndex`'s template, plus the usage of the existing `trim_snippet` template tag follows the existing implementation for transcripts.
