### PR TITLE
Re-work indexed author metadata for search results

### DIFF
--- a/web/nuremberg/documents/models.py
+++ b/web/nuremberg/documents/models.py
@@ -397,6 +397,10 @@ class DocumentPersonalAuthor(models.Model):
             'properties': [],
         }
 
+        # If no properties were requested, return early with base metadata
+        if max_properties is not None and max_properties < 1:
+            return result
+
         if ranks is None:  # reuse rank information between exploded properties
             ranks = dict(
                 PersonalAuthorPropertyRank.objects.all().values_list(

--- a/web/nuremberg/documents/search_indexes.py
+++ b/web/nuremberg/documents/search_indexes.py
@@ -84,12 +84,7 @@ class DocumentIndex(indexes.SearchIndex, indexes.Indexable):
     def prepare_authors_properties(self, document):
         result = [
             author.metadata() for author in document.group_authors.all()
-        ] + document.personal_authors.all().order_by('id').metadata(
-            max_properties=8,
-            max_property_values=4,
-            max_qualifiers=3,
-            max_qualifier_values=3,
-        )
+        ] + document.personal_authors.all().metadata(max_properties=0)
         # json modifiers for the most compact json representation
         return json.dumps(result, indent=None, separators=(',', ':'))
 

--- a/web/nuremberg/documents/tests/test_models.py
+++ b/web/nuremberg/documents/tests/test_models.py
@@ -148,6 +148,25 @@ def test_author_properties_no_author():
     assert empty_qs.metadata() == []
 
 
+def test_author_properties_max_properties_zero(django_assert_num_queries):
+    author = make_author()
+
+    with django_assert_num_queries(0):
+        result = author.metadata(max_properties=0)
+
+    assert result == {
+        'author': {
+            'name': author.full_name(),
+            'id': author.id,
+            'slug': author.slug,
+            'title': author.title,
+            'description': '',
+        },
+        'image': None,
+        'properties': [],
+    }
+
+
 def test_author_properties_no_property_match_uses_title():
     author = make_author(
         first_name='No',

--- a/web/nuremberg/search/templates/search/document-row.html
+++ b/web/nuremberg/search/templates/search/document-row.html
@@ -143,7 +143,8 @@
       </a>
     {% else %}
       {% for author_prop in result.authors_properties %}
-        {% include 'documents/_author_properties_hover.html' with include_title=False %}
+        {% get_item authors_metadata author_prop.author.id fallback=author_prop as author_prop %}
+        {% include 'documents/_author_properties_hover.html' with author_prop=author_prop include_title=False %}
       {% endfor %}
     {% endif %}
   </td>

--- a/web/nuremberg/search/templatetags/search_url.py
+++ b/web/nuremberg/search/templatetags/search_url.py
@@ -139,3 +139,8 @@ def group_merge(results, key):
 @register.filter
 def trim_snippet(snippet):
     return SafeString((snippet.split('<end of text>', 1)[0]).strip())
+
+
+@register.simple_tag
+def get_item(mapping, key, fallback=None):
+    return mapping.get(key, fallback)


### PR DESCRIPTION
Previous logic for indexing author metadata would store the whole metadata dict for each author of each document in the index. This generated potentially (very) big json-encoded fields that would make Solr error for some cases (see issue #62 in the previous repo: https://github.com/nessita/revsys-nuremberg-deprecated/issues/62).

This branch do not store all the author properties, but instead it would query the database for the metadata list, once per author across all matching docs.