### PR TITLE
Tidy up document details page

### DIFF
--- a/web/nuremberg/core/static/style/documents.less
+++ b/web/nuremberg/core/static/style/documents.less
@@ -244,3 +244,10 @@ html.touchevents & {
 .printed-document-summary {
   display: none;
 }
+
+/* This class is triplicated from search.less and search-results.less */
+.ellipsis {
+  font-style: italic;
+  color: @gray;
+  white-space: nowrap;
+}

--- a/web/nuremberg/documents/models.py
+++ b/web/nuremberg/documents/models.py
@@ -167,6 +167,7 @@ class Document(models.Model):
                 ),
             )
             .filter(evidence_code__in=evidence_codes)
+            .order_by('source__name')
         )
 
 

--- a/web/nuremberg/documents/templates/documents/show.html
+++ b/web/nuremberg/documents/templates/documents/show.html
@@ -244,18 +244,29 @@
       {% endwith %}
 
       <!-- Summary (taken from external sources) -->
-      {% with document.external_metadata.all as external_metadata %}
+      {% with external_metadata=document.external_metadata.all codes_length=evidence_codes|length %}
       {% if external_metadata %}
         <h2 class="h6">Document Summary</h2>
         <div class="summary">
-          {% for item in external_metadata %}
-          <div class="accordion {% if forloop.first %}active{% endif %}" title="{{ item.source.description }}">
-            {{ item.source.name }}
+
+        {% regroup external_metadata by source as source_list %}
+        {% for source in source_list %}
+          <div class="accordion {% if forloop.first %}active{% endif %}" title="{{ source.grouper.description }}">
+            {{ source.grouper.name }}
           </div>
           <div class="accordion-panel {% if forloop.first %}active{% endif %}">
-            <p><strong>{{ item.evidence_code }}</strong>: {{ item.summary }}</p>
-          </div>
+          {% for item in source.list|slice:6 %}
+            <p>
+              {% if codes_length > 1 %}<strong>{{ item.evidence_code }}</strong>: {% endif %}
+              {{ item.summary }}
+            </p>
           {% endfor %}
+          {% if source.list|length > 6 %}
+          <span class="ellipsis">[ ... ]</span>
+          {% endif %}
+          </div>
+        {% endfor %}
+
         </div>
       {% endif %}
       {% endwith %}

--- a/web/nuremberg/documents/templates/documents/show.html
+++ b/web/nuremberg/documents/templates/documents/show.html
@@ -38,6 +38,7 @@
       </div>
       <hr />
     {% endif %}
+    {% if mode != 'text' %}
     <div class="document-tools">
       {% block document_controls %}
         <div class="zoom-buttons">
@@ -74,8 +75,9 @@
         </a>
       </div>
     </div>
+    <hr />
+    {% endif %}
   {% endblock %}
-  <hr />
   <div class="sidebar-layout">
     <div class="sidebar-column document-info">
       <div class="material-icon small material-documents"></div>

--- a/web/nuremberg/documents/templates/documents/show.html
+++ b/web/nuremberg/documents/templates/documents/show.html
@@ -110,7 +110,9 @@
       </div>
       {% endif %}
       <h1 class="h3" aria-role="heading" aria-level="1">{{document.title}}</h1>
+      {% if document.literal_title %}
       <div class="h5">{{document.literal_title}}</div>
+      {% endif %}
       {% block document_details %}
         <p class="date">
           {% with document.date as date %}


### PR DESCRIPTION
- Do not show Document's literal_title if unset
- Only show zoom and page controls for document image details
- Group external metadata by source. Limit summaries to 6 per source.