### PR TITLE
Add new section to landing page: project news

### DIFF
--- a/web/nuremberg/content/models.py
+++ b/web/nuremberg/content/models.py
@@ -1,7 +1,10 @@
 from django.db import models
+from django.utils.functional import cached_property
 
 
 class AnalystReport(models.Model):
+    REPORT_PREFIX = "Document Analyst's Report"
+
     id = models.AutoField(db_column='RecordID', primary_key=True)
     analyst = models.CharField(db_column='Analyst', max_length=100)
     date = models.DateField(db_column='DateSort')
@@ -11,6 +14,16 @@ class AnalystReport(models.Model):
     class Meta:
         managed = False
         db_table = 'tblDocAnalystReports'
+        # by default, sort by "date" from newest to older
+        ordering = ['-date']
+
+    @cached_property
+    def content(self):
+        # simple text purging, for more complex stuff we should move to regexes
+        result = self.report.strip()
+        if result.startswith(self.REPORT_PREFIX):
+            result = result[len(self.REPORT_PREFIX) :]
+        return result.strip()
 
 
 class TrialInfo(models.Model):

--- a/web/nuremberg/content/templates/content/landing.html
+++ b/web/nuremberg/content/templates/content/landing.html
@@ -7,6 +7,27 @@
 
 {% block body_class %}landing-page{% endblock %}
 
+{% block javascript %}
+  {{ block.super }}
+  <script>
+    var select = document.querySelector('#report-select-date')
+
+    select.addEventListener('change', function(){
+      var shown_reports = document.getElementsByClassName("report-content show")
+      var i;
+
+      for (i = 0; i < shown_reports.length; i++) {
+        shown_reports[i].classList.add("hide");
+        shown_reports[i].classList.remove("show");
+      };
+
+      document.getElementById(select.value).classList.remove("hide");
+      document.getElementById(select.value).classList.add("show");
+    })
+
+  </script>
+{% endblock %}
+
 {% block content %}
 <section class="landing-hero">
   {% include 'nav.html' %}
@@ -99,19 +120,33 @@
   </footer>
 </section>
 
-<section class="theme-beige project-news">
-  <h2>TBD: Nuremberg Project News</h2>
-  <ul>
-    <li><a href="https://www.youtube.com/watch?v=finv6A3qRKg&feature=youtu.be">Treasures of the Harvard Law School Library</a></li>
-    <li><a href="https://hls.harvard.edu/today/notes-nuremberg-documentarian/">Notes of a Nuremberg Documentarian</a></li>
-    <li><a href="https://news.harvard.edu/gazette/story/2016/10/devils-in-the-details/">Devil's in the Details</a></li>
-  </ul>
+<section class="project-news">
 
-  <h2>TBD: Document Analyst's Report</h2>
-  {% for report in reports %}
-  <p><strong>{{ report.date }}</strong> {{ report.report|truncatewords:50 }}</p>
-  {% endfor %}
+  <div class="two-column-layout project-news">
+    <div class="column project-new-links">
+      <h2>Nuremberg Project News</h2>
+      <a class="teaser" href="https://www.youtube.com/watch?v=finv6A3qRKg&feature=youtu.be"> Treasures of the Harvard Law School Library </a>
+      <a class="teaser" href="https://hls.harvard.edu/today/notes-nuremberg-documentarian/"> Notes of a Nuremberg Documentarian </a>
+      <a class="teaser" href="https://news.harvard.edu/gazette/story/2016/10/devils-in-the-details/"> Devil's in the Details </a>
+    </div>
 
+    <div class="column project-new-reports">
+      <div class="two-column-layout">
+      <div class="column"><h2>Document Analyst's Report</h2></div>
+      <div class="column report-date">
+        <select id="report-select-date">
+          {% for report in reports %}<option value="report-{{ report.id }}">{{ report.date_display }}</option>{% endfor %}
+        </select>
+      </div>
+      </div>
+      {% for report in reports %}
+      <div id="report-{{ report.id }}" class="report-content {% if forloop.first %}show{% else %}hide{% endif %}">
+        <p>{{ report.content|truncatewords:75 }}</p>
+        <a class="teaser" href="{% url 'content:report-detail' report.pk %}"> Continue Reading </a>
+      </div>
+      {% endfor %}
+    </div>
+  </div>
 </section>
 
 <section class="theme-beige approaches">

--- a/web/nuremberg/content/templates/content/report.html
+++ b/web/nuremberg/content/templates/content/report.html
@@ -1,0 +1,30 @@
+{% extends "base.html" %}
+{% load i18n %}
+{% load static %}
+
+{% block title %}Document Analyst's Report{% endblock %}
+
+{% block body_class %}analyst-report{% endblock %}
+
+{% block content %}
+<section class="theme-light report">
+<h2>Document Analyst's Report</h2>
+
+<div class="three-column-layout nav-date">
+  <div class="column previous-report">
+    {% if previous %}
+    <a href="{% url 'content:report-detail' previous.pk %}">Previous: {{ previous.date_display }}</a>
+    {% endif %}
+  </div>
+  <div class="column"><h3>{{ object.date_display }}</h3></div>
+  <div class="column next-report">
+    {% if next %}
+    <a href="{% url 'content:report-detail' next.pk %}">Next: {{ next.date_display }}</a>
+    {% endif %}
+  </div>
+</div>
+
+<p>{{ object.content }}</p>
+
+</section>
+{% endblock %}

--- a/web/nuremberg/content/urls.py
+++ b/web/nuremberg/content/urls.py
@@ -1,5 +1,5 @@
-from django.urls import re_path
-from .views import ContentView, LandingView
+from django.urls import path, re_path
+from .views import ContentView, LandingView, ReportDetailView
 
 app_name = 'content'
 urlpatterns = [
@@ -77,5 +77,8 @@ urlpatterns = [
         r'^nmt_7_intro$',
         ContentView.as_view(template_name='content/nmt_7_intro.html'),
         name="nmt_7_intro",
+    ),
+    path(
+        'reports/<int:pk>/', ReportDetailView.as_view(), name='report-detail'
     ),
 ]

--- a/web/nuremberg/content/views.py
+++ b/web/nuremberg/content/views.py
@@ -1,4 +1,5 @@
 from django.views.generic import TemplateView
+from django.views.generic.detail import DetailView
 
 from nuremberg.content.models import AnalystReport
 
@@ -16,3 +17,18 @@ class LandingView(ContentView):
 
     template_name = 'content/landing.html'
     context = {'query': '', 'reports': AnalystReport.objects.all()}
+
+
+class ReportDetailView(DetailView):
+
+    model = AnalystReport
+    template_name = 'content/report.html'
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        for pos in ('next', 'previous'):
+            try:
+                context[pos] = getattr(self.object, f'get_{pos}_by_date')()
+            except AnalystReport.DoesNotExist:
+                context[pos] = None
+        return context

--- a/web/nuremberg/core/static/style/base.less
+++ b/web/nuremberg/core/static/style/base.less
@@ -120,6 +120,9 @@ a.bypass-link {
   }
 }
 
+
+/* Maybe split into its own author-dropdown.less file? */
+
 .dropdown {
   position: relative;
   display: inline-block;
@@ -152,4 +155,17 @@ a.bypass-link {
 
 .dropdown-content .see-more-details{
   float: right;
+}
+
+
+/* Maybe split into its own report.less file? */
+body.analyst-report {
+  .nav-date {
+    text-align: center;
+  }
+
+  h3 {
+    margin: 0;
+  }
+
 }

--- a/web/nuremberg/core/static/style/landing.less
+++ b/web/nuremberg/core/static/style/landing.less
@@ -282,6 +282,47 @@ section {
     }
   }
 
+  .project-news {
+    padding: 12px 0 5px;
+
+    .project-new-links {
+      width: 30%;
+
+      h3 {
+        text-align: center;
+      }
+
+      a {
+        display: block;
+        margin: 20px;
+      }
+
+    }
+
+    .project-new-reports {
+      width: 70%;
+      .serif-text(normal, 16px, 26px);
+
+      a {
+        float: right;
+      }
+
+      #report-select-date {
+        margin-top: 20px;
+        float:right;
+      }
+
+      .hide {
+        display: none;
+      }
+
+      .show {
+        display: block;
+      }
+
+    }
+  }
+
 }
 
 .progress-summary p {
@@ -378,6 +419,7 @@ section {
       background-color: #7A7C8D;
     }
   }
+
 }
 
 .sidebar-layout .main-column:last-child {

--- a/web/nuremberg/core/static/style/layout.less
+++ b/web/nuremberg/core/static/style/layout.less
@@ -114,6 +114,19 @@ hr {
   }
 }
 
+.two-column-layout {
+  &:extend(.row);
+
+  .column {
+    .make-md-column(6);
+  }
+
+  &.serif p {
+    .serif-text(normal, 16px, 25px);
+  }
+
+}
+
 .three-column-layout {
   &:extend(.row);
 


### PR DESCRIPTION
The 3 sections Approaches, Trial Transcripts, and Project Progress should be replaced by the 2 new sections The Trials and Nuremberg Project News and Project Analyst's Reports

The reports are taken from the dedicated model in the DB and there is also a new report detail view provided.