### PR TITLE
Author fly-out: limit the amount of property values to max 4

### DIFF
--- a/web/nuremberg/documents/templates/documents/_author_properties.html
+++ b/web/nuremberg/documents/templates/documents/_author_properties.html
@@ -16,7 +16,7 @@
 {% for item in properties %}
   <li data-test="author-property">
     <strong>{{ item.name|capfirst }}:</strong>
-    {% for prop in item.prop_values %}
+    {% for prop in item.prop_values|slice:max_property_values %}
         {% if prop.qualifiers %}
           {{ prop.value }}
           <small>({% qualifierformat prop.qualifiers max_qualifiers=max_qualifiers max_qualifier_values=max_qualifier_values %})</small>{% if not forloop.last %}; {% endif %}

--- a/web/nuremberg/documents/templates/documents/_author_properties_hover.html
+++ b/web/nuremberg/documents/templates/documents/_author_properties_hover.html
@@ -10,7 +10,7 @@
             {% if author_prop.properties %}
             <p><a class="see-more-details" href="{% url 'documents:author' author_id=author_prop.author.id author_slug=author_prop.author.slug %}">See more details</a></p>
             {% endif %}
-            {% include 'documents/_author_properties.html' with author=author_prop.author image=author_prop.image properties=author_prop.properties|slice:":8" max_qualifiers=3 max_qualifier_values=3 %}
+            {% include 'documents/_author_properties.html' with author=author_prop.author image=author_prop.image properties=author_prop.properties|slice:":8" max_property_values=4 max_qualifiers=3 max_qualifier_values=3 %}
           </div>
       </div>
 {% endwith %}

--- a/web/nuremberg/documents/templates/documents/author.html
+++ b/web/nuremberg/documents/templates/documents/author.html
@@ -7,7 +7,7 @@
 {% block content %}
 <section class="theme-light results">
 
-{% include 'documents/_author_properties.html' with properties=properties max_qualifiers=None max_qualifier_values=5 %}
+{% include 'documents/_author_properties.html' with properties=properties max_property_values=None max_qualifiers=None max_qualifier_values=5 %}
 
 </section>
 {% endblock %}

--- a/web/nuremberg/search/templates/search/document-row.html
+++ b/web/nuremberg/search/templates/search/document-row.html
@@ -145,6 +145,7 @@
       {% for author_prop in result.authors_properties %}
         {% get_item authors_metadata author_prop.author.id fallback=author_prop as author_prop %}
         {% include 'documents/_author_properties_hover.html' with author_prop=author_prop include_title=False %}
+        {% if not forloop.last %}<br />{% endif %}
       {% endfor %}
     {% endif %}
   </td>


### PR DESCRIPTION
Search results: each author should appear in their own line