### PR TITLE
Document details: conditionally show citation links

### DIFF
--- a/dumps/nuremberg_prod_dump_latest.sqlite3.zip
+++ b/dumps/nuremberg_prod_dump_latest.sqlite3.zip
@@ -1,1 +1,1 @@
-nuremberg_prod_dump_2023-02-02T16:25:59.sqlite3.zip
+nuremberg_prod_dump_2023-02-07T14:40:56.sqlite3.zip

--- a/web/nuremberg/documents/models.py
+++ b/web/nuremberg/documents/models.py
@@ -985,8 +985,8 @@ class DocumentCitation(models.Model):
     @cached_property
     def transcript_link(self):
         result = None
-        if self.case.transcript:
-            t_id = self.case.transcript.id
+        transcript = getattr(self.case, 'transcript', None)
+        if transcript is not None:
             qs = None
             if self.transcript_seq_number is None:
                 qs = {'page': self.transcript_page_number}
@@ -994,7 +994,7 @@ class DocumentCitation(models.Model):
                 qs = {'seq': self.transcript_seq_number}
             if qs:
                 result = (
-                    reverse('transcripts:show', args=(t_id,))
+                    reverse('transcripts:show', args=(transcript.id,))
                     + '?'
                     + urlencode(qs)
                 )

--- a/web/nuremberg/documents/templates/documents/show.html
+++ b/web/nuremberg/documents/templates/documents/show.html
@@ -208,21 +208,14 @@
         {% endfor %}
         {% endwith %}
 
-        {% with document.citations.all as citations %}
         {% if citations %}
         <p>
           <strong>Citation{{ citations|length|pluralize }}:</strong>
           {% for citation in citations %}
-            {% if citation.case.transcript %}
-            <a href="{% url 'transcripts:show' citation.case.transcript.id %}?page={{ citation.transcript_page_number }}">
-              {{ citation.case.tag_name }} (page {{ citation.transcript_page_number }})</a>{% if not forloop.last %}, {% endif %}
-          {% else %}
-              {{ citation.case.tag_name }} (page {{ citation.transcript_page_number }}){% if not forloop.last %}, {% endif %}
-          {% endif %}
+          <a href="{{ citation.transcript_link }}">{{ citation.case.tag_name }} (page {{ citation.transcript_page_number }})</a>{% if not forloop.last %}, {% endif %}
           {% endfor %}
         </p>
         {% endif %}
-        {% endwith %}
 
         <p>
           <strong>HLSL Item No.:</strong>

--- a/web/nuremberg/documents/views.py
+++ b/web/nuremberg/documents/views.py
@@ -61,6 +61,9 @@ class Show(View):
                 'hlsl_item_id': hlsl_item_id,
                 'mode': mode,
                 'evidence_codes': evidence_codes,
+                'citations': [
+                    c for c in document.citations.all() if c.transcript_link
+                ],
                 'query': query,
             },
         )


### PR DESCRIPTION
The transcript citation links are now conditionally shown depending on the information from the `tblCasesDatesList`. When the value of the column `TranscriptCitationSeqNo` is NULL, citation links are shown as before.
When 0, citation links are suppressed, and when not NULL and non zero, a link to the transcript with reference to the sequence number is provided.