### PR TITLE
Ensure document text highlight handles exact phrases

### DIFF
--- a/web/nuremberg/documents/views.py
+++ b/web/nuremberg/documents/views.py
@@ -1,3 +1,5 @@
+import re
+
 from django.http import JsonResponse
 from django.shortcuts import get_object_or_404, render
 from django.views.generic import View
@@ -6,7 +8,30 @@ from haystack.utils import Highlighter
 from .models import Document, DocumentPersonalAuthor, DocumentText
 
 
+EXACT_PHRASE_RE = re.compile(r'"([^"]*)"|([^"]*)')
+
+
 class DocumentHighlighter(Highlighter):
+    def __init__(self, query, **kwargs):
+        super().__init__(query, **kwargs)
+
+        # Extract all exact phrases and treat them as "a single word"
+        matches = EXACT_PHRASE_RE.findall(query)
+        exact_phrases, non_exact = list(zip(*matches))
+        self.query_words = {
+            phrase.strip().lower()
+            for phrase in exact_phrases
+            if phrase.strip()
+        }
+        self.query_words.update(
+            {
+                word.strip().lower()
+                for item in non_exact
+                for word in item.split()
+                if item and not word.startswith("-")
+            }
+        )
+
     def find_window(self, highlight_locations):
         # Do not truncate the text at all -- show everything, from start to end
         return (0, len(self.text_block))

--- a/web/nuremberg/settings.py
+++ b/web/nuremberg/settings.py
@@ -7,10 +7,12 @@ env = environ.Env()
 environ.Env.read_env()
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
-BASE_DIR = Path(env.str(
-    'BASE_DIR',
-    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
-))
+BASE_DIR = Path(
+    env.str(
+        'BASE_DIR',
+        os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    )
+)
 
 LOCAL_DEVELOPMENT = env.bool("LOCAL_DEVELOPMENT", default=False)
 


### PR DESCRIPTION
This branch extends the custom Highlighter so search terms for exact phrase match (ie using double quotes) is acknowledged and respected when doing the actual highlighting.