### PR TITLE
Assorted fixes for various document and transcript pages

### DIFF
--- a/web/nuremberg/documents/models.py
+++ b/web/nuremberg/documents/models.py
@@ -1025,9 +1025,12 @@ class DocumentCitation(models.Model):
         result = None
         if transcript is not None:
             qs = None
-            if self.transcript_seq_number is None:
+            if (
+                self.transcript_seq_number is None
+                and self.transcript_page_number
+            ):
                 qs = {'page': self.transcript_page_number}
-            elif self.transcript_seq_number > 0:
+            elif self.transcript_seq_number:
                 qs = {'seq': self.transcript_seq_number}
             if qs:
                 result = (

--- a/web/nuremberg/documents/templates/documents/show.html
+++ b/web/nuremberg/documents/templates/documents/show.html
@@ -88,7 +88,6 @@
     <div class="sidebar-column document-info">
       <div class="material-icon small material-documents"></div>
 
-      {% with cases=document.cases.all %}
       {% if cases %}
       <p class="trial-flags">
         {% for case in document.cases.all %}
@@ -97,7 +96,7 @@
         &nbsp;
       </p>
       {% endif %}
-      {% endwith %}
+
       {% if mode == 'image' and full_text %}
       <p class="trial-flags">
         <a data-test="full-text-view" href="{% url 'documents:show' document_id=full_text.id slug=full_text.slug %}?mode=text{% if query %}&q={% encode_string query %}{% endif %}">Full-text View</a>
@@ -188,7 +187,9 @@
           <p>
             <strong>Exhibit Code{{ exhibit_codes|length|pluralize }}:</strong>
             {% for code in exhibit_codes %}
-              {% if code.prosecution_number or code.defense_number %}
+              {% if code.prosecution_number %}
+                <a href="{% search_query exhibit=code trial=cases.first.code_name %}">{{code}}</a>{% if not forloop.last %}, {% endif %}
+              {% elif code.defense_number %}
                 <a href="{% search_query exhibit=code %}">{{code}}</a>{% if not forloop.last %}, {% endif %}
               {% endif %}
             {% endfor %}

--- a/web/nuremberg/documents/templates/documents/show.html
+++ b/web/nuremberg/documents/templates/documents/show.html
@@ -225,7 +225,7 @@
 
         {% if document.description %}
         <p>
-          <strong>Notes:</strong>
+          <strong>Notes:</strong>{{ document.description|stringformat:'r' }}
           {{ document.description }}
         </p>
         {% endif %}

--- a/web/nuremberg/documents/tests/test_models.py
+++ b/web/nuremberg/documents/tests/test_models.py
@@ -183,6 +183,38 @@ def test_document_citations_transcript_link_none():
     assert doc.citations.get().transcript_link is None
 
 
+def test_document_citations_transcript_link_page_number_none():
+    doc = baker.make('Document')
+    citation = baker.make(
+        'DocumentCitation',
+        document=doc,
+        transcript_seq_number=None,
+        transcript_page_number=None,
+    )
+    transcript = baker.make('Transcript', case=citation.case)
+
+    assert citation.case is not None
+    assert getattr(citation.case, 'transcript', None) is transcript
+    assert doc.citations.all().count() == 1
+    assert doc.citations.get().transcript_link is None
+
+
+def test_document_citations_transcript_link_page_number_zero():
+    doc = baker.make('Document')
+    citation = baker.make(
+        'DocumentCitation',
+        document=doc,
+        transcript_seq_number=None,
+        transcript_page_number=0,
+    )
+    transcript = baker.make('Transcript', case=citation.case)
+
+    assert citation.case is not None
+    assert getattr(citation.case, 'transcript', None) is transcript
+    assert doc.citations.all().count() == 1
+    assert doc.citations.get().transcript_link is None
+
+
 def test_document_citations_transcript_link_page_number():
     doc = baker.make('Document')
     citation = baker.make(

--- a/web/nuremberg/documents/views.py
+++ b/web/nuremberg/documents/views.py
@@ -20,6 +20,7 @@ class Show(View):
             full_text = get_object_or_404(DocumentText, id=document_id)
             document = full_text.documents().first()
             evidence_codes = [full_text.evidence_code]
+            exhibit_codes = cases = None
             if document is None:
                 # For texts without a matching document, ignore `HLSL Item No.`
                 document = full_text
@@ -45,10 +46,8 @@ class Show(View):
             evidence_codes = document.evidence_codes.all()
             hlsl_item_id = document_id
             exhibit_codes = document.exhibit_codes.all()
+            cases = document.cases.all()
 
-        print("CODES!!!")
-        print(exhibit_codes)
-        print(exhibit_codes[0].pk)
         return render(
             request,
             self.template_name,
@@ -59,6 +58,7 @@ class Show(View):
                 'mode': mode,
                 'evidence_codes': evidence_codes,
                 'exhibit_codes': exhibit_codes,
+                'cases': cases,
                 'citations': [
                     c for c in document.citations.all() if c.transcript_link
                 ],

--- a/web/nuremberg/transcripts/templates/transcripts/base.html
+++ b/web/nuremberg/transcripts/templates/transcripts/base.html
@@ -16,9 +16,6 @@
             <a href="{% sort_results 'relevance' %}" {% if form.sort_results == 'relevance' %}class="active"{% endif %}>Order by Relevance</a>
           {% endif %}
         </form>
-        <div class="return-link">
-          <a href="{% search_url query %}"> &larr; Back to all results </a>
-        </div>
       </div>
       <hr />
     {% endif %}

--- a/web/nuremberg/transcripts/templates/transcripts/search.html
+++ b/web/nuremberg/transcripts/templates/transcripts/search.html
@@ -30,7 +30,7 @@
         No results found in this transcript.
       </p>
       <p>
-        <a href="{% search_query query %}">Click here to search for "{{query}}" in all documents.</a>
+        <a href="{% search_query query %}">Click here to search for {{ query }} in all documents.</a>
       </p>
     {% endfor %}
   </div>

--- a/web/nuremberg/transcripts/templates/transcripts/show.html
+++ b/web/nuremberg/transcripts/templates/transcripts/show.html
@@ -76,7 +76,6 @@ t
     </div>
   {% endblock %}
 
-  <p class="module">{{transcript.description}}</p>
   <div class="print-show"></div>
   {% with transcript.activities.all as activities %}
   {% if activities %}


### PR DESCRIPTION
Fixed #208 -- Remove "Back to all results" link from transcript-context pages
Fixed #210 -- For prosecution document no. link in document metadata, add trial number to link query
Fixed #211 -- Remove redundant double-quoting of search-query below transcript search box
Fixed #212 -- Remove transcript note below transcript icon on right
Fixed #229 -- Suppress transcript citation link when citation page number = 0