### PR TITLE
Strip tags on results

### DIFF
--- a/web/nuremberg/search/templates/search/document-row.html
+++ b/web/nuremberg/search/templates/search/document-row.html
@@ -69,7 +69,7 @@
               {% if document.highlighted %}
                 {{ document.highlighted.highlight.0|trim_snippet }}
               {% else %}
-                {{ document.text|slice:":150"|trim_snippet }}
+                {{ document.text|striptags|slice:":150"|trim_snippet }}
               {% endif %}
             {% endfor %}
           {% endif %}


### PR DESCRIPTION
- Removing all tags in the template to avoid overflowing the <td> element

- Fixes #275