### PR TITLE
Adjust search results when dealing with full text documents.

### DIFF
--- a/web/nuremberg/core/static/style/search-results.less
+++ b/web/nuremberg/core/static/style/search-results.less
@@ -69,3 +69,12 @@ mark {
     .page-arrow('right');
   }
 }
+
+.full-text {
+  .label();
+  .sans-serif(normal, 11px, 11px);
+
+  border: 1px solid @dark-gray;
+  background-color: @lighter-gray;
+  color: @dark-gray;
+}

--- a/web/nuremberg/documents/views.py
+++ b/web/nuremberg/documents/views.py
@@ -51,12 +51,15 @@ class Show(View):
             full_text = document.full_texts().first()
             evidence_codes = document.evidence_codes.all()
             hlsl_item_id = document_id
+            cases = document.cases.all()
             exhibit_codes = document.exhibit_codes.all()
             for e in exhibit_codes:
                 if str(e) != "":
                     all_exhibit_codes_empty = False
-
-            cases = document.cases.all()
+            if mode == 'search-text':
+                # When coming from a search result matching a doc full-text,
+                # always show the text version by default (#237).
+                mode = 'text'
 
         citations = []
         try:

--- a/web/nuremberg/search/templates/search/document-row.html
+++ b/web/nuremberg/search/templates/search/document-row.html
@@ -16,9 +16,8 @@
         {% if result.literal_title %}
           <p>{{result.literal_title|truncatewords:35|truncatechars:300}}</p>
         {% endif %}
-        {% with result.text|trim_snippet as text %}
         <p>{{group.hits}} result{{ group.hits|pluralize }} in this document</p>
-        {% if text and has_keyword_search %}
+        {% if result.full_text and has_keyword_search %}
         <p class="snippets">
             {% for snippet in result.highlighted.highlight %}
               <span class="ellipsis">[ ... ]</span>
@@ -30,7 +29,6 @@
           <span class="ellipsis">[ ... ]</span>
         </p>
         {% endif %}
-        {% endwith %}
         <p><strong>HLSL Item No.:</strong> {{result.pk}}</p>
       </a>
     {% elif result.material_type == 'Photograph' %}

--- a/web/nuremberg/search/templates/search/document-row.html
+++ b/web/nuremberg/search/templates/search/document-row.html
@@ -9,6 +9,9 @@
       {% for case in result.case_tags %}
         <span class="trial-flag trial-{{case|slugify}}">{{case}}</span>
       {% endfor %}
+      {% if result.full_text %}
+        <span class="full-text">Full Text</span>
+      {% endif %}
     </p>
     {% if result.material_type == 'Document' %}
       <a class="unstyled" href="{% url 'documents:show' document_id=result.pk slug=result.slug %}?mode={{ result.mode }}{% if query %}&q={% encode_string query %}{% endif %}">


### PR DESCRIPTION
Show "full-text" document label on search results (#238).
Show doc full text on details page when coming from search results (#237).