### PR TITLE
Ensured that exhibit codes are shown for documents having non empty codes.

### DIFF
--- a/web/nuremberg/documents/templates/documents/show.html
+++ b/web/nuremberg/documents/templates/documents/show.html
@@ -225,7 +225,7 @@
           </p>
         {% endif %}
         {% if exhibit_codes %}
-          {% if all_evidence_codes_not_empty %}
+          {% if not all_exhibit_codes_empty %}
             <p>
               <strong>Exhibit Code{{ exhibit_codes|length|pluralize }}:</strong>
               {% for code in exhibit_codes %}


### PR DESCRIPTION
Fixes #394.